### PR TITLE
Allow CORS to /basket URLs

### DIFF
--- a/config/cors.php
+++ b/config/cors.php
@@ -17,7 +17,7 @@ return [
     |
     */
 
-    'paths' => ['api/*', 'sanctum/csrf-cookie'],
+    'paths' => ['api/*', 'basket/*', 'sanctum/csrf-cookie'],
 
     'allowed_methods' => ['*'],
 


### PR DESCRIPTION
Add /basket to the set of paths that allow CORS requests, so JSON searches can work from the webserial view.