### PR TITLE
UI: fix spelling for preferred editor label

### DIFF
--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -61,7 +61,7 @@
                         </div>
 
                         <div class="form-group{{ $errors->has('editor') ? ' has-error' : '' }}">
-                            <label for="password" class="col-md-4 control-label">Prefered editor</label>
+                            <label for="password" class="col-md-4 control-label">Preferred editor</label>
 
                             <div class="col-md-6">
                                 <select id="editor" class="form-control" name="editor">

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -50,7 +50,7 @@
                             </div>
 
                             <div class="form-group{{ $errors->has('editor') ? ' has-error' : '' }}">
-                                <label for="password" class="col-md-4 control-label">Prefered editor</label>
+                                <label for="password" class="col-md-4 control-label">Preferred editor</label>
 
                                 <div class="col-md-6">
                                     <select id="editor" class="form-control" name="editor">


### PR DESCRIPTION
Tiny nitpick (can be upstreamed since the badge.team version also has the same issue) - fix spelling prefered -> preferred in the register and edit user UI.